### PR TITLE
only escape closing square brackets inside <a> tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -305,7 +305,7 @@ class MarkdownConverter(object):
 
         # escape special characters if we're not inside a preformatted or code element
         if '_noformat' not in parent_tags:
-            text = self.escape(text)
+            text = self.escape(text, parent_tags)
 
         # remove leading whitespace at the start or just after a
         # block-level element; remove traliing whitespace at the end
@@ -347,11 +347,16 @@ class MarkdownConverter(object):
         else:
             return True
 
-    def escape(self, text):
+    def escape(self, text, parent_tags):
         if not text:
             return ''
         if self.options['escape_misc']:
-            text = re.sub(r'([]\\&<`[>~=+|])', r'\\\1', text)
+            text = re.sub(r'([\\&<`[>~=+|])', r'\\\1', text)
+
+            if 'a' in parent_tags:
+                # inside <a> tags, also escape closing brackets in link text
+                text = re.sub(r'(])', r'\\\1', text)
+
             # A sequence of one or more consecutive '-', preceded and
             # followed by whitespace or start/end of fragment, might
             # be confused with an underline of a header, or with a

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -51,7 +51,7 @@ def test_misc():
     assert md('-y', escape_misc=True) == '-y'
     assert md('+ x\n+ y\n', escape_misc=True) == '\\+ x\n\\+ y\n'
     assert md('`x`', escape_misc=True) == r'\`x\`'
-    assert md('[text](notalink)', escape_misc=True) == r'\[text\](notalink)'
+    assert md('[text](notalink)', escape_misc=True) == r'\[text](notalink)'
     assert md('<a href="link">text]</a>', escape_misc=True) == r'[text\]](link)'
     assert md('<a href="link">[text]</a>', escape_misc=True) == r'[\[text\]](link)'
     assert md('1. x', escape_misc=True) == r'1\. x'


### PR DESCRIPTION
Escapes closing square brackets only inside `<a>` tags.

This is similar to how many HTML serializers escape opening `<` characters but not closing `>` characters. In theory, as long as *all* opening brackets are escaped, a stray closing bracket outside a link should not be misinterpreted.

@jsm28 - would appreciate your thoughts on this!